### PR TITLE
Compatibility with SS3.2

### DIFF
--- a/javascript/MapField.js
+++ b/javascript/MapField.js
@@ -147,12 +147,12 @@
 			},
 
 			getFieldValue: function(fieldName) {
-				var value = $('#'+this.attr('name')+'-'+fieldName).val();
+				var value = $(this).find('[name="'+this.attr('name')+'['+fieldName+']"]').val();
 				return value;
 			},
 
 			setFieldValue: function(fieldName, value) {
-				$('#'+this.attr('name')+'-'+fieldName).val(value);
+				$(this).find('[name="'+this.attr('name')+'['+fieldName+']"]').val(value);
 				$('.cms-edit-form').addClass('changed');
 			}
 		});


### PR DESCRIPTION
SS3.2 changed the way how it prepares ID values and `-` is replaced with `_`.
But to keep it backwards compatible it is better to search by `name` attribute.
Also, it is better to search for a field inside Map object, not globally. Otherwise it may return wrong field if you have more then one field in page.
